### PR TITLE
Allow logging of exceeded rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ TrafficJam configuration object can be accessed with `TrafficJam.config` or in a
 
 **key_prefix** (default: "traffic_jam"): The string prefixing all keys in Redis.
 
+**logger** (optional): A logger used to log all exceeded rate limits.
+
 ### Registering limits
 
 Fixed limits can be registered for a key if the cap does not change depending on the value. All instance methods are available on the class.

--- a/lib/traffic_jam/configuration.rb
+++ b/lib/traffic_jam/configuration.rb
@@ -3,7 +3,7 @@ module TrafficJam
   #
   # @see TrafficJam#configure
   class Configuration
-    OPTIONS = %i( key_prefix hash_length redis )
+    OPTIONS = %i( key_prefix hash_length redis logger )
 
     # @!attribute redis
     #   @return [Redis] the connected Redis client the library uses
@@ -12,6 +12,8 @@ module TrafficJam
     # @!attribute hash_length
     #   @return [String] the number of characters to use from the Base64 encoded
     #     hashes of the limit values
+    # @!attribute logger
+    #   @return [Logger] the logger object to be used for logging that a limit was exceeded
     attr_accessor *OPTIONS
 
     def initialize(options = {})

--- a/lib/traffic_jam/limit.rb
+++ b/lib/traffic_jam/limit.rb
@@ -98,6 +98,15 @@ module TrafficJam
     #   limit
     def increment!(amount = 1, time: Time.now)
       if !increment(amount, time: time)
+        if logger.present?
+          logger.info(
+            message: "Exceeded Limit - Action: #{action}, Value: #{value}, Max: #{max}, Limit: #{limit}",
+            action: action,
+            value: value,
+            max: max,
+            limit: limit
+          )
+        end
         raise TrafficJam::LimitExceededError.new(self)
       end
     end
@@ -158,6 +167,10 @@ module TrafficJam
 
     def redis
       config.redis
+    end
+
+    def logger
+      config.logger
     end
 
     def key


### PR DESCRIPTION
1. Added logger as a new configuration option.
2. Use the configured logger to log that a rate limit was exceeded.
