### PR TITLE
Moves from using hgetall to hmget for limit checking.

### DIFF
--- a/lib/traffic_jam/limit.rb
+++ b/lib/traffic_jam/limit.rb
@@ -127,9 +127,7 @@ module TrafficJam
     def used
       return 0 if max.zero?
 
-      obj = redis.hgetall(key)
-      timestamp = obj['timestamp']
-      amount = obj['amount']
+      timestamp, amount = redis.hmget(key, 'timestamp', 'amount')
       if timestamp && amount
         time_passed = Time.now.to_f - timestamp.to_i / 1000.0
         drift = max * time_passed / period


### PR DESCRIPTION
The limit checking was using `hgetall` to retrieve all the keys in a hash, but
it only needed two specific keys from it. This changes to using `hmget` for the
two keys needed to be more efficient.

@jimpo @grahamjenson