### PR TITLE
 [feature] Add RollingLimit and LifetimeLimit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - "2.0.0"
-  - "2.1.5"
+  - "2.3.5"
+  - "2.4.2"
 services:
   - redis-server

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'coveralls', require: false
   gem 'minitest', '~> 5.5.1'
+  gem 'simplecov', require: false
   gem 'spy', '~> 0.4.1'
   gem 'timecop', '~> 0.7.1'
-  gem 'simplecov', require: false
-  gem 'coveralls', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    traffic_jam (1.0.1)
+    traffic_jam (1.0.2)
       redis (~> 3.0)
 
 GEM
@@ -19,7 +19,7 @@ GEM
     multi_json (1.10.1)
     netrc (0.10.3)
     rake (10.4.2)
-    redis (3.2.1)
+    redis (3.3.3)
     rest-client (1.7.3)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
@@ -48,4 +48,4 @@ DEPENDENCIES
   traffic_jam!
 
 BUNDLED WITH
-   1.10.3
+   1.15.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-  t.pattern = 'spec/*_spec.rb'
+  t.pattern = 'spec/**/*_spec.rb'
 end
 
 task default: [:test]

--- a/lib/traffic_jam.rb
+++ b/lib/traffic_jam.rb
@@ -4,7 +4,8 @@ require_relative 'traffic_jam/errors'
 require_relative 'traffic_jam/configuration'
 require_relative 'traffic_jam/limit'
 require_relative 'traffic_jam/limit_group'
-
+require_relative 'traffic_jam/rolling_limit'
+require_relative 'traffic_jam/lifetime_limit'
 
 module TrafficJam
   include Errors

--- a/lib/traffic_jam/lifetime_limit.rb
+++ b/lib/traffic_jam/lifetime_limit.rb
@@ -1,0 +1,53 @@
+module TrafficJam
+  # This class represents a lifetime limit on an action, value pair. For example, if
+  # limiting the amount of money a user can transfer, the action could be
+  # +:transfers+ and the value would be the user ID. The class exposes atomic
+  # increment operations and allows querying of the current amount used and
+  # amount remaining.
+  class LifetimeLimit < Limit
+    # Constructor takes an action name as a symbol, a maximum cap, and the
+    # period of limit. +max+ and +period+ are required keyword arguments.
+    #
+    # @param action [Symbol] action name
+    # @param value [String] limit target value
+    # @param max [Integer] required limit maximum
+    # @raise [ArgumentError] if max is nil
+    def initialize(action, value, max: nil)
+      super(action, value, max: max, period: -1)
+    end
+
+    # Increment the amount used by the given number. Does not perform increment
+    # if the operation would exceed the limit. Returns whether the operation was
+    # successful.
+    #
+    # @param amount [Integer] amount to increment by
+    # @return [Boolean] true if increment succeded and false if incrementing
+    #   would exceed the limit
+    def increment(amount = 1, time: Time.now)
+      raise ArgumentError, 'Amount must be an integer' if amount != amount.to_i
+      return amount <= 0 if max.zero?
+
+      !!run_script([amount.to_i, max])
+    end
+
+    # Return amount of limit used
+    #
+    # @return [Integer] amount used
+    def used
+      return 0 if max.zero?
+      amount = redis.get(key) || 0
+      [amount.to_i, max].min
+    end
+
+    private
+
+    def run_script(argv)
+      redis.evalsha(
+        Scripts::INCRBY_HASH, keys: [key], argv: argv
+      )
+    rescue Redis::CommandError => error
+      raise error if /ERR Error running script/ =~ error.message
+      redis.eval(Scripts::INCRBY, keys: [key], argv: argv)
+    end
+  end
+end

--- a/lib/traffic_jam/limit.rb
+++ b/lib/traffic_jam/limit.rb
@@ -78,7 +78,7 @@ module TrafficJam
         begin
           redis.evalsha(
             Scripts::INCREMENT_SCRIPT_HASH, keys: [key], argv: argv)
-        rescue Redis::CommandError => e
+        rescue Redis::CommandError
           redis.eval(Scripts::INCREMENT_SCRIPT, keys: [key], argv: argv)
         end
 
@@ -159,7 +159,7 @@ module TrafficJam
     end
 
     def key
-      if @key.nil?
+      if !defined?(@key) || @key.nil?
         converted_value =
           begin
             value.to_rate_limit_value

--- a/lib/traffic_jam/rolling_limit.rb
+++ b/lib/traffic_jam/rolling_limit.rb
@@ -1,0 +1,82 @@
+require_relative 'scripts'
+
+module TrafficJam
+  # This class represents a rolling limit on an action, value pair. For example,
+  # if limiting the amount of money a user can transfer in a week, the action
+  # could be +:transfers+ and the value would be the user ID. The class exposes
+  # atomic increment operations and allows querying of the current amount used
+  # and amount remaining.
+  #
+  # This class also handles 0 for period, where 0 is no period (each
+  # request is compared to the max).
+  #
+  # This class departs from the design of Limit by tracking a sum of the actions
+  # in a second, in a hash keyed by the timestamp. Therefore, this limit can put
+  # a lot of data size pressure on the Redis storage, so use it wisely.
+  class RollingLimit < Limit
+    # Constructor takes an action name as a symbol, a maximum cap, and the
+    # period of limit. +max+ and +period+ are required keyword arguments.
+    #
+    # @param action [Symbol] action name
+    # @param value [String] limit target value
+    # @param max [Integer] required limit maximum
+    # @param period [Integer] required limit period in seconds
+    # @raise [ArgumentError] if max or period is nil
+    def initialize(action, value, max: nil, period: nil)
+      super(action, value, max: max, period: period)
+    end
+
+    # Increment the amount used by the given number. Rolls back the increment
+    # if the operation exceeds the limit. Returns whether the operation was
+    # successful. Time of increment can be specified optionally with a keyword
+    # argument, which is not really useful since it be undone by used.
+    #
+    # @param amount [Integer] amount to increment by
+    # @param time [Time] time when increment occurs (ignored)
+    # @return [Boolean] true if increment succeded and false if incrementing
+    #   would exceed the limit
+    def increment(amount = 1, time: Time.now)
+      raise ArgumentError, 'Amount must be an integer' if amount != amount.to_i
+      return amount <= 0 if max.zero?
+      return amount <= max if period.zero?
+      return true if amount.zero?
+      return false if amount > max
+
+      !run_incr([time.to_i, amount.to_i, max, period]).nil?
+    end
+
+    # Return amount of limit used
+    #
+    # @return [Integer] amount used
+    def used
+      return 0 if max.zero? || period.zero?
+      [sum, max].min
+    end
+
+    private
+
+    def sum
+      run_sum([Time.now.to_i, period])
+    end
+
+    def clear_before
+      Time.now.to_i - period
+    end
+
+    def run_sum(argv)
+      redis.evalsha(Scripts::SUM_ROLLING_HASH, keys: [key], argv: argv)
+    rescue Redis::CommandError => error
+      raise error if /ERR Error running script/ =~ error.message
+      redis.eval(Scripts::SUM_ROLLING, keys: [key], argv: argv)
+    end
+
+    def run_incr(argv)
+      redis.evalsha(
+        Scripts::INCREMENT_ROLLING_HASH, keys: [key], argv: argv
+      )
+    rescue Redis::CommandError => error
+      raise error if /ERR Error running script/ =~ error.message
+      redis.eval(Scripts::INCREMENT_ROLLING, keys: [key], argv: argv)
+    end
+  end
+end

--- a/lib/traffic_jam/scripts.rb
+++ b/lib/traffic_jam/scripts.rb
@@ -10,5 +10,11 @@ module TrafficJam
 
     INCREMENT_SCRIPT = load('increment')
     INCREMENT_SCRIPT_HASH = Digest::SHA1.hexdigest(INCREMENT_SCRIPT)
+    INCREMENT_ROLLING = load('increment_rolling')
+    INCREMENT_ROLLING_HASH = Digest::SHA1.hexdigest(INCREMENT_ROLLING)
+    INCRBY = load('incrby')
+    INCRBY_HASH = Digest::SHA1.hexdigest(INCRBY)
+    SUM_ROLLING = load('sum_rolling')
+    SUM_ROLLING_HASH = Digest::SHA1.hexdigest(SUM_ROLLING)
   end
 end

--- a/scripts/incrby.lua
+++ b/scripts/incrby.lua
@@ -1,0 +1,18 @@
+local arg_amount = tonumber(ARGV[1])
+local arg_max = tonumber(ARGV[2])
+
+local old_amount = tonumber(redis.call("GET", KEYS[1]))
+local new_amount
+
+if not old_amount then
+  new_amount = arg_amount
+else
+  new_amount = old_amount + arg_amount
+
+  if new_amount > arg_max then
+    return false
+  end
+end
+
+redis.call("INCRBY", KEYS[1], arg_amount)
+return true

--- a/scripts/increment_rolling.lua
+++ b/scripts/increment_rolling.lua
@@ -1,0 +1,44 @@
+-- gets all fields from a hash as a dictionary
+local hgetall = function (key)
+  local bulk = redis.call('HGETALL', key)
+	local result = {}
+	local nextkey
+	for i, v in ipairs(bulk) do
+		if i % 2 == 1 then
+			nextkey = v
+		else
+			result[nextkey] = v
+		end
+	end
+	return result
+end
+
+local arg_timestamp = tonumber(ARGV[1])
+local arg_amount = tonumber(ARGV[2])
+local arg_max = tonumber(ARGV[3])
+local arg_period = tonumber(ARGV[4])
+
+local sum = arg_amount
+
+local clear_before = arg_timestamp - arg_period
+local mytable = hgetall(KEYS[1])
+if mytable ~= false then
+  -- print key -> value for mytable
+  print('mytable:')
+  for key, val in pairs(mytable) do
+    print('    ' .. key .. ' -> ' .. val)
+    if tonumber(key) < clear_before then
+      redis.call('HDEL', KEYS[1], key)
+    else
+      sum = sum + tonumber(val)
+    end
+  end
+end
+
+if sum > arg_max then
+  return false
+end
+
+redis.call("HINCRBY", KEYS[1], arg_timestamp, arg_amount)
+redis.call("EXPIRE", KEYS[1], arg_period)
+return true

--- a/scripts/sum_rolling.lua
+++ b/scripts/sum_rolling.lua
@@ -1,0 +1,32 @@
+-- gets all fields from a hash as a dictionary
+local hgetall = function (key)
+  local bulk = redis.call('HGETALL', key)
+	local result = {}
+	local nextkey
+	for i, v in ipairs(bulk) do
+		if i % 2 == 1 then
+			nextkey = v
+		else
+			result[nextkey] = v
+		end
+	end
+	return result
+end
+
+local arg_timestamp = tonumber(ARGV[1])
+local arg_period = tonumber(ARGV[2])
+local sum = 0
+
+local clear_before = arg_timestamp - arg_period
+local mytable = hgetall(KEYS[1])
+if mytable ~= false then
+  for key, val in pairs(mytable) do
+    if tonumber(key) < clear_before then
+      redis.call('HDEL', KEYS[1], key)
+    else
+      sum = sum + tonumber(val)
+    end
+  end
+end
+
+return sum

--- a/spec/traffic_jam/lifetime_limit_spec.rb
+++ b/spec/traffic_jam/lifetime_limit_spec.rb
@@ -1,0 +1,84 @@
+require_relative '../spec_helper'
+
+describe TrafficJam::RollingLimit do
+  include RedisHelper
+
+  TrafficJam.configure do |config|
+    config.redis = RedisHelper.redis
+  end
+
+  let(:max) { 3 }
+  let(:limit) do
+    TrafficJam::LifetimeLimit.new(:test, 'user1', max: max)
+  end
+
+  after do
+    Spy.teardown
+  end
+
+  describe :increment do
+    it 'should be true when rate limit is not exceeded' do
+      assert limit.increment(1)
+    end
+
+    it 'should be false when raise limit is exceeded' do
+      assert limit.increment(1)
+      assert limit.increment(2)
+      assert !limit.increment(1)
+    end
+
+    it 'should be a no-op when limit would be exceeded' do
+      limit.increment(2)
+      assert !limit.increment(2)
+      assert limit.increment(1)
+    end
+
+    it 'should be false when any time passes' do
+      assert limit.increment(3)
+      Timecop.travel(4000)
+      assert !limit.increment(1)
+    end
+
+    it 'should only call eval once' do
+      eval_spy = Spy.on(RedisHelper.redis, :eval).and_call_through
+      limit.increment(1)
+      limit.increment(1)
+      limit.increment(1)
+      assert_equal 1, eval_spy.calls.count
+    end
+
+    describe 'when max is changed to a lower amount' do
+      it 'should never expire' do
+        limit = TrafficJam::LifetimeLimit.new(:test, 'user1', max: 4)
+        limit.increment!(4)
+
+        limit = TrafficJam::LifetimeLimit.new(:test, 'user1', max: 2)
+        assert !limit.increment(0)
+        assert_equal 2, limit.used
+      end
+    end
+  end
+
+  describe :used do
+    it 'should be 0 when there has been no incrementing' do
+      assert_equal 0, limit.used
+    end
+
+    it 'should be the amount used' do
+      limit.increment(1)
+      assert_equal 1, limit.used
+    end
+
+    it 'should not decrease over time' do
+      limit.increment(2)
+      Timecop.travel(60 / 2)
+      assert_equal 2, limit.used
+    end
+
+    it 'should not exceed maximum when limit changes' do
+      limit.increment!(3)
+      limit2 = TrafficJam::LifetimeLimit.new(:test, 'user1', max: 2)
+      assert_equal 2, limit2.used
+    end
+  end
+end

--- a/spec/traffic_jam/rolling_limit_spec.rb
+++ b/spec/traffic_jam/rolling_limit_spec.rb
@@ -1,0 +1,144 @@
+require_relative '../spec_helper'
+
+describe TrafficJam::RollingLimit do
+  include RedisHelper
+
+  TrafficJam.configure do |config|
+    config.redis = RedisHelper.redis
+  end
+
+  let(:max) { 3 }
+  let(:limit) do
+    TrafficJam::RollingLimit.new(:test, 'user1', max: max, period: period)
+  end
+
+  after do
+    Spy.teardown
+  end
+
+  describe :increment do
+    let(:period) { 60 * 60 }
+
+    it 'should raise an argument error if given a float' do
+      assert_raises(ArgumentError) do
+        limit.increment(1.5)
+      end
+    end
+
+    describe 'when max is zero' do
+      let(:max) { 0 }
+      it 'should be false for any amount' do
+        assert !limit.increment
+      end
+    end
+  end
+
+  describe 'one time' do
+    let(:period) { 0 }
+
+    describe :increment do
+      it 'should be true when rate limit is not exceeded' do
+        assert limit.increment(1)
+      end
+
+      it 'should be false when raise limit is exceeded' do
+        assert limit.increment(3)
+        assert limit.increment(3)
+        assert !limit.increment(4)
+      end
+
+      it 'should never call eval' do
+        eval_spy = Spy.on(RedisHelper.redis, :eval).and_call_through
+        limit.increment(1)
+        assert_equal 0, eval_spy.calls.count
+      end
+    end
+
+    describe :used do
+      it 'should be 0' do
+        assert_equal 0, limit.used
+        limit.increment(1)
+        assert_equal 0, limit.used
+      end
+    end
+  end
+
+  describe 'timeframe' do
+    let(:period) { 60 * 60 }
+
+    describe :increment do
+      it 'should be true when limit is not exceeded' do
+        assert limit.increment(1)
+      end
+
+      it 'should be false when limit is exceeded' do
+        assert limit.increment(1)
+        assert limit.increment(2)
+        assert !limit.increment(1)
+      end
+
+      it 'should be a no-op when limit would be exceeded' do
+        assert limit.increment(2)
+        assert !limit.increment(2)
+        assert limit.increment(1)
+      end
+
+      it 'should be true when sufficient time passes' do
+        assert limit.increment(3)
+        Timecop.travel(period / 2)
+        assert !limit.increment(1)
+        Timecop.travel(period)
+        assert limit.increment(3)
+      end
+
+      describe 'when max is zero' do
+        let(:max) { 0 }
+        it 'should be false for any positive amount' do
+          assert !limit.increment
+        end
+      end
+
+      describe 'when max is changed to a lower amount' do
+        it 'should still expire after period' do
+          limit = TrafficJam::RollingLimit.new(
+            :test, 'user1', max: 4, period: period
+          )
+          limit.increment!(4)
+
+          limit = TrafficJam::RollingLimit.new(
+            :test, 'user1', max: 2, period: period
+          )
+          assert !limit.increment
+
+          Timecop.travel(period + 1)
+          assert_equal 0, limit.used
+        end
+      end
+    end
+
+    describe :used do
+      it 'should be 0 when there has been no incrementing' do
+        assert_equal 0, limit.used
+      end
+
+      it 'should be the amount used' do
+        limit.increment(1)
+        assert_equal 1, limit.used
+      end
+
+      it 'should not decrease over time' do
+        limit.increment(2)
+        Timecop.travel(period / 2)
+        assert_equal 2, limit.used
+      end
+
+      it 'should not exceed maximum when limit changes' do
+        limit.increment!(3)
+        limit2 = TrafficJam::RollingLimit.new(
+          :test, 'user1', max: 2, period: period
+        )
+        assert_equal 2, limit2.used
+      end
+    end
+  end
+end

--- a/spec/traffic_jam_limit_spec.rb
+++ b/spec/traffic_jam_limit_spec.rb
@@ -27,6 +27,10 @@ describe TrafficJam do
   end
 
   describe :increment do
+    after do
+      Spy.teardown
+    end
+
     it "should be true when rate limit is not exceeded" do
       assert limit.increment(1)
     end

--- a/spec/traffic_jam_spec.rb
+++ b/spec/traffic_jam_spec.rb
@@ -9,60 +9,60 @@ describe TrafficJam do
     config.register(:test4, 4, 60)
   end
 
-  let(:user) { "user1" }
+  let(:value) { "user1" }
 
   describe '::limit' do
     it "should return limit instance with registered limits" do
-      limit = TrafficJam.limit(:test, user)
+      limit = TrafficJam.limit(:test, value)
       assert_equal :test, limit.action
-      assert_equal user, limit.value
+      assert_equal value, limit.value
       assert_equal 3, limit.max
       assert_equal 60, limit.period
     end
 
     it "should raise error if not found" do
       assert_raises(TrafficJam::LimitNotFound) do
-        TrafficJam.limit(:test2, user)
+        TrafficJam.limit(:test2, value)
       end
     end
   end
 
   describe '::reset_all' do
     it "should reset all rate limits" do
-      limit = TrafficJam.increment!(:test, user)
-      limit = TrafficJam.increment!(:test4, user)
-      assert_equal 1, TrafficJam.used(:test, user)
-      assert_equal 1, TrafficJam.used(:test4, user)
+      limit = TrafficJam.increment!(:test, value)
+      limit = TrafficJam.increment!(:test4, value)
+      assert_equal 1, TrafficJam.used(:test, value)
+      assert_equal 1, TrafficJam.used(:test4, value)
 
       TrafficJam.reset_all
-      assert_equal 0, TrafficJam.used(:test, user)
-      assert_equal 0, TrafficJam.used(:test4, user)
+      assert_equal 0, TrafficJam.used(:test, value)
+      assert_equal 0, TrafficJam.used(:test4, value)
     end
 
     it "should reset all rate limits for one action" do
-      limit = TrafficJam.increment!(:test, user)
-      limit = TrafficJam.increment!(:test4, user)
-      assert_equal 1, TrafficJam.used(:test, user)
-      assert_equal 1, TrafficJam.used(:test4, user)
+      limit = TrafficJam.increment!(:test, value)
+      limit = TrafficJam.increment!(:test4, value)
+      assert_equal 1, TrafficJam.used(:test, value)
+      assert_equal 1, TrafficJam.used(:test4, value)
 
       TrafficJam.reset_all(action: :test)
-      assert_equal 0, TrafficJam.used(:test, user)
-      assert_equal 1, TrafficJam.used(:test4, user)
+      assert_equal 0, TrafficJam.used(:test, value)
+      assert_equal 1, TrafficJam.used(:test4, value)
     end
   end
 
   describe 'class helpers' do
     before { TrafficJam.config.register(:test, 3, 60) }
-    let(:user) { "user1" }
+    let(:value) { "user1" }
 
     it "should call methods with registered limits" do
-      TrafficJam.increment(:test, user, 1)
-      assert_equal 1, TrafficJam.used(:test, user)
+      TrafficJam.increment(:test, value, 1)
+      assert_equal 1, TrafficJam.used(:test, value)
     end
 
     it "should raise error if limit not found" do
       assert_raises(TrafficJam::LimitNotFound) do
-        TrafficJam.increment(:test2, user, 1)
+        TrafficJam.increment(:test2, value, 1)
       end
     end
   end

--- a/spec/traffic_jam_spec.rb
+++ b/spec/traffic_jam_spec.rb
@@ -9,60 +9,60 @@ describe TrafficJam do
     config.register(:test4, 4, 60)
   end
 
-  let(:value) { "user1" }
+  let(:user) { "user1" }
 
   describe '::limit' do
     it "should return limit instance with registered limits" do
-      limit = TrafficJam.limit(:test, value)
+      limit = TrafficJam.limit(:test, user)
       assert_equal :test, limit.action
-      assert_equal value, limit.value
+      assert_equal user, limit.value
       assert_equal 3, limit.max
       assert_equal 60, limit.period
     end
 
     it "should raise error if not found" do
       assert_raises(TrafficJam::LimitNotFound) do
-        TrafficJam.limit(:test2, value)
+        TrafficJam.limit(:test2, user)
       end
     end
   end
 
   describe '::reset_all' do
     it "should reset all rate limits" do
-      limit = TrafficJam.increment!(:test, value)
-      limit = TrafficJam.increment!(:test4, value)
-      assert_equal 1, TrafficJam.used(:test, value)
-      assert_equal 1, TrafficJam.used(:test4, value)
+      limit = TrafficJam.increment!(:test, user)
+      limit = TrafficJam.increment!(:test4, user)
+      assert_equal 1, TrafficJam.used(:test, user)
+      assert_equal 1, TrafficJam.used(:test4, user)
 
       TrafficJam.reset_all
-      assert_equal 0, TrafficJam.used(:test, value)
-      assert_equal 0, TrafficJam.used(:test4, value)
+      assert_equal 0, TrafficJam.used(:test, user)
+      assert_equal 0, TrafficJam.used(:test4, user)
     end
 
     it "should reset all rate limits for one action" do
-      limit = TrafficJam.increment!(:test, value)
-      limit = TrafficJam.increment!(:test4, value)
-      assert_equal 1, TrafficJam.used(:test, value)
-      assert_equal 1, TrafficJam.used(:test4, value)
+      limit = TrafficJam.increment!(:test, user)
+      limit = TrafficJam.increment!(:test4, user)
+      assert_equal 1, TrafficJam.used(:test, user)
+      assert_equal 1, TrafficJam.used(:test4, user)
 
       TrafficJam.reset_all(action: :test)
-      assert_equal 0, TrafficJam.used(:test, value)
-      assert_equal 1, TrafficJam.used(:test4, value)
+      assert_equal 0, TrafficJam.used(:test, user)
+      assert_equal 1, TrafficJam.used(:test4, user)
     end
   end
 
   describe 'class helpers' do
     before { TrafficJam.config.register(:test, 3, 60) }
-    let(:value) { "user1" }
+    let(:user) { "user1" }
 
     it "should call methods with registered limits" do
-      TrafficJam.increment(:test, value, 1)
-      assert_equal 1, TrafficJam.used(:test, value)
+      TrafficJam.increment(:test, user, 1)
+      assert_equal 1, TrafficJam.used(:test, user)
     end
 
     it "should raise error if limit not found" do
       assert_raises(TrafficJam::LimitNotFound) do
-        TrafficJam.increment(:test2, value, 1)
+        TrafficJam.increment(:test2, user, 1)
       end
     end
   end

--- a/traffic_jam.gemspec
+++ b/traffic_jam.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "traffic_jam"
-  s.version     = "1.0.1"
+  s.version     = "1.0.2"
   s.licenses    = ["MIT"]
   s.summary     = "Library for time-based rate limiting"
   s.description = "Library for Redis-backed time-based rate limiting"


### PR DESCRIPTION
Feature

Reason:
  There was a requirement to have hard limits rather than the windowed limits where the limit could be exceeded in the time period. Additionally, there was a need to have a lifetime (cumulative) and one time limits, which extended from Limit so that the interface would not change.

