### PR TITLE
Truncate timestamp to millisecond instead of round.

### DIFF
--- a/lib/traffic_jam/limit.rb
+++ b/lib/traffic_jam/limit.rb
@@ -71,7 +71,7 @@ module TrafficJam
         raise ArgumentError.new("Amount must be an integer")
       end
 
-      timestamp = (time.to_f * 1000).round
+      timestamp = (time.to_f * 1000).to_i
       argv = [timestamp, amount.to_i, max, period * 1000]
 
       result =


### PR DESCRIPTION
This was causing test flakes if #used was queried within the .5ms gap between after increment was called and before the next millisecond barrier.